### PR TITLE
use the appropriate C++ 'cast' operator and fix the South plugin API …

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -101,19 +101,19 @@ PLUGIN_HANDLE plugin_init(ConfigCategory *config)
 /**
  * Poll for a plugin reading
  */
-Reading plugin_poll(PLUGIN_HANDLE *handle)
+Reading plugin_poll(PLUGIN_HANDLE handle)
 {
-	DHT11 *dht11 = (DHT11*)handle;
+	DHT11 *dht11 = static_cast<DHT11*>(handle);
 	return dht11->takeReading();
 }
 
 /**
  * Reconfigure the plugin
  */
-void plugin_reconfigure(PLUGIN_HANDLE *handle, string& newConfig)
+void plugin_reconfigure(PLUGIN_HANDLE handle, string& newConfig)
 {
-ConfigCategory	conf("dht", newConfig);
-DHT11 *dht11 = (DHT11*)*handle;
+	ConfigCategory conf("dht", newConfig);
+	DHT11 *dht11 = static_cast<DHT11*>(handle);
 
 	if (conf.itemExists("asset"))
                 dht11->setAssetName(conf.getValue("asset"));
@@ -127,9 +127,9 @@ DHT11 *dht11 = (DHT11*)*handle;
 /**
  * Shutdown the plugin
  */
-void plugin_shutdown(PLUGIN_HANDLE *handle)
+void plugin_shutdown(PLUGIN_HANDLE handle)
 {
-	DHT11 *dht11 = (DHT11*)handle;
+	DHT11 *dht11 = static_cast<DHT11*>(handle);
 	delete dht11;
 }
 };


### PR DESCRIPTION
…signatures

The C cast operator for the 'PLUGIN_HANDLE' variable is too permissive.

Use the C++ 'static_cast': the cast operation is performed at the build time and the compiler checks the compatibility and consistency between the types.

We also need to fix the signatures of the API functions that contain 'PLUGIN_HANDLE',
and because of this, we are consistant with the North plugin API.

The Fledge documentation [1], that contains an example based on this DHT11 South plugin, will also be updated.

[1] https://fledge-iot.readthedocs.io/en/develop/plugin_developers_guide/03_south_C_plugins.html

Signed-off-by: Mikael Bourhis <mikael.bourhis@smile.fr>