### PR TITLE
Fix 'plugin_reconfigure()' input parameter type

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -110,10 +110,10 @@ Reading plugin_poll(PLUGIN_HANDLE handle)
 /**
  * Reconfigure the plugin
  */
-void plugin_reconfigure(PLUGIN_HANDLE handle, string& newConfig)
+void plugin_reconfigure(PLUGIN_HANDLE *handle, string& newConfig)
 {
 	ConfigCategory conf("dht", newConfig);
-	DHT11 *dht11 = static_cast<DHT11*>(handle);
+	DHT11 *dht11 = static_cast<DHT11*>(*handle);
 
 	if (conf.itemExists("asset"))
                 dht11->setAssetName(conf.getValue("asset"));


### PR DESCRIPTION
The Fledge API requires 'PLUGIN_HANDLE *' as input parameter for 'plugin_reconfigure()'.
But for the other 'plugin_*' functions, only 'PLUGIN_HANDLE' (that represents a 'void *') is required.

See '$FLEDGE_ROOT/C/services/south/include/south_plugin.h' for finding the function pointers used by Fledge, and their signature.

Signed-off-by: Mikael Bourhis <mikael.bourhis@smile.fr>